### PR TITLE
Add `rel="external noopener"` to external webpage links in template.html

### DIFF
--- a/template.html
+++ b/template.html
@@ -75,8 +75,8 @@ breadcrumbs:
                     <div class="wiki-heading">
                         <h1>$title$</h1>
                         <div>
-                            <a href="$repo$/edit/master/$file$.md">Edit This Page</a>
-                            <a href="$repo$/new/master/$path$">New Page</a>
+                            <a rel="external noopener" href="$repo$/edit/master/$file$.md">Edit This Page</a>
+                            <a rel="external noopener" href="$repo$/new/master/$path$">New Page</a>
                         </div>
                     </div>
                     $if(subtitle)$

--- a/template.html
+++ b/template.html
@@ -75,8 +75,8 @@ breadcrumbs:
                     <div class="wiki-heading">
                         <h1>$title$</h1>
                         <div>
-                            <a rel="external noopener" href="$repo$/edit/master/$file$.md">Edit This Page</a>
-                            <a rel="external noopener" href="$repo$/new/master/$path$">New Page</a>
+                            <a rel="external noopener" href="$repo$/edit/master/$file$.md" target="_blank">Edit This Page</a>
+                            <a rel="external noopener" href="$repo$/new/master/$path$" target="_blank">New Page</a>
                         </div>
                     </div>
                     $if(subtitle)$


### PR DESCRIPTION
Closely related to pr in `cucyber.github.io` repository.

Add "external" relationship to specify link as external, and add "noopener" to prevent webpage/browser hijacking.